### PR TITLE
fix: allow checksum-verified unsigned Windows updates

### DIFF
--- a/VntcApp1.0/lib/update/update_service.dart
+++ b/VntcApp1.0/lib/update/update_service.dart
@@ -273,7 +273,11 @@ class AppUpdateService {
       throw StateError('安装包不存在：${result.filePath}');
     }
     _ensureSupportedWindowsSilentInstaller(result);
-    await _verifyWindowsInstallerAuthenticode(installer);
+    await _verifyDownloadedFile(installer, result.asset);
+    await _verifyWindowsInstallerAuthenticode(
+      installer,
+      sha256Verified: true,
+    );
 
     final appDir = path.dirname(Platform.resolvedExecutable);
     final storageRoot = (await _resolveDownloadDirectory()).path;
@@ -819,7 +823,10 @@ class AppUpdateService {
     }
   }
 
-  Future<void> _verifyWindowsInstallerAuthenticode(File installer) async {
+  Future<void> _verifyWindowsInstallerAuthenticode(
+    File installer, {
+    required bool sha256Verified,
+  }) async {
     final command = '''
 \$signature = Get-AuthenticodeSignature -LiteralPath ${_psString(installer.path)}
 \$subject = if (\$signature.SignerCertificate) { \$signature.SignerCertificate.Subject } else { '' }
@@ -847,10 +854,11 @@ class AppUpdateService {
     }
     final status = (decoded['Status'] ?? '').toString();
     final subject = (decoded['Subject'] ?? '').toString();
-    if (!isTrustedWindowsSignature(
+    if (!isAcceptedWindowsInstallerTrust(
       status: status,
       subject: subject,
       trustedPublisher: AppUpdateConfig.windowsTrustedPublisherName,
+      sha256Verified: sha256Verified,
     )) {
       const publisherHint = AppUpdateConfig.windowsTrustedPublisherName;
       throw StateError(
@@ -1593,6 +1601,24 @@ bool isTrustedWindowsSignature({
     return true;
   }
   return subject.toLowerCase().contains(publisher.toLowerCase());
+}
+
+bool isAcceptedWindowsInstallerTrust({
+  required String status,
+  required String subject,
+  required String trustedPublisher,
+  required bool sha256Verified,
+}) {
+  if (isTrustedWindowsSignature(
+    status: status,
+    subject: subject,
+    trustedPublisher: trustedPublisher,
+  )) {
+    return true;
+  }
+  return trustedPublisher.trim().isEmpty &&
+      status.trim().toLowerCase() == 'notsigned' &&
+      sha256Verified;
 }
 
 int compareVersionStrings(String left, String right) {

--- a/VntcApp1.0/test/update_service_test.dart
+++ b/VntcApp1.0/test/update_service_test.dart
@@ -187,6 +187,36 @@ void main() {
         isFalse,
       );
     });
+
+    test('accepts unsigned installer only after sha256 verification', () {
+      expect(
+        isAcceptedWindowsInstallerTrust(
+          status: 'NotSigned',
+          subject: '',
+          trustedPublisher: '',
+          sha256Verified: true,
+        ),
+        isTrue,
+      );
+      expect(
+        isAcceptedWindowsInstallerTrust(
+          status: 'NotSigned',
+          subject: '',
+          trustedPublisher: '',
+          sha256Verified: false,
+        ),
+        isFalse,
+      );
+      expect(
+        isAcceptedWindowsInstallerTrust(
+          status: 'NotSigned',
+          subject: '',
+          trustedPublisher: 'VNTC Publisher',
+          sha256Verified: true,
+        ),
+        isFalse,
+      );
+    });
   });
 
   group('AppUpdateProxyResolver', () {


### PR DESCRIPTION
## 变更

- Windows 静默更新启动前再次验证安装包大小与 SHA256
- 配置受信任发布者时继续强制 Authenticode 有效且证书主题匹配
- 未配置发布者时，仅允许 SHA256 已重新验证的 `NotSigned` 安装包

## 原因

当前发布环境未配置代码签名证书，3.9 安装包为 `NotSigned`。旧逻辑会在下载并成功校验 SHA256 后仍拒绝安装，导致用户无法通过内置更新器升级。

## 验证

- `flutter analyze --no-pub`
- `flutter test --no-pub`：106/106
- Windows 3.9 安装包与便携包重新构建成功